### PR TITLE
`OVH_REDIRECT` function + redirects fix

### DIFF
--- a/dns/dnsconfig.js
+++ b/dns/dnsconfig.js
@@ -1,3 +1,4 @@
-require('./providers.js') // Providers and DNS Providers
+require("./providers.js"); // Providers
+require_glob("./functions/"); // Functions
 
-require_glob('./domains/') // Domains
+require_glob("./domains/"); // Domains

--- a/dns/domains/akademiaurzadzania.pl.js
+++ b/dns/domains/akademiaurzadzania.pl.js
@@ -3,11 +3,8 @@ D("akademiaurzadzania.pl", REGISTRAR_NONE, DnsProvider(PROVIDER_OVH),
 
   // OVH Domain Redirection
   // https://forum.rootnode.pl/topic/1228-www-in-txt-3welcome/?do=findComment&comment=11633
-  TXT("@", "4|designcoach.pl"), // Redirect to designcoach.pl [302]
-  TXT("www", "4|designcoach.pl"),
-
-  A("@", LUTHARON),
-  A("www", LUTHARON),
+  OVH_REDIRECT("@", "https://designcoach.pl", 302),
+  OVH_REDIRECT("www", "https://designcoach.pl", 302),
 
   MX("@", 10, "mx3.mail.ovh.net."),
   MX("@", 1, "mx4.mail.ovh.net.")

--- a/dns/domains/homecoach.pl.js
+++ b/dns/domains/homecoach.pl.js
@@ -3,11 +3,8 @@ D("homecoach.pl", REGISTRAR_NONE, DnsProvider(PROVIDER_OVH),
 
   // OVH Domain Redirection
   // https://forum.rootnode.pl/topic/1228-www-in-txt-3welcome/?do=findComment&comment=11633
-  TXT("@", "4|designcoach.pl"), // Redirect to designcoach.pl [302]
-  TXT("www", "4|designcoach.pl"),
-
-  A("@", LUTHARON),
-  A("www", LUTHARON),
+  OVH_REDIRECT("@", "https://designcoach.pl", 302),
+  OVH_REDIRECT("www", "https://designcoach.pl", 302),
 
   MX("@", 10, "mx3.mail.ovh.net."),
   MX("@", 1, "mx4.mail.ovh.net.")

--- a/dns/domains/qubatura.art.js
+++ b/dns/domains/qubatura.art.js
@@ -3,8 +3,8 @@ D("qubatura.art", REGISTRAR_OVH, DnsProvider(PROVIDER_OVH),
 
   // OVH Domain Redirection
   // https://forum.rootnode.pl/topic/1228-www-in-txt-3welcome/?do=findComment&comment=11633
-  TXT("@", "4|www.qubatura.com.pl"), // Redirect to qubatura.com.pl [302]
-  TXT("www", "4|www.qubatura.com.pl"),
+  OVH_REDIRECT("@", "https://qubatura.com.pl", 302),
+  OVH_REDIRECT("www", "https://qubatura.com.pl", 302),
 
   MX("@", 10, "mx3.mail.ovh.net."),
   MX("@", 1, "mx4.mail.ovh.net."),

--- a/dns/domains/wnetrzabardzoosobiste.pl.js
+++ b/dns/domains/wnetrzabardzoosobiste.pl.js
@@ -3,11 +3,8 @@ D("wnetrzabardzoosobiste.pl", REGISTRAR_NONE, DnsProvider(PROVIDER_OVH),
 
   // OVH Domain Redirection
   // https://forum.rootnode.pl/topic/1228-www-in-txt-3welcome/?do=findComment&comment=11633
-  TXT("@", "4|designcoach.pl"), // Redirect to designcoach.pl [302]
-  TXT("www", "4|designcoach.pl"),
-
-  A("@", LUTHARON),
-  A("www", LUTHARON),
+  OVH_REDIRECT("@", "https://designcoach.pl", 302),
+  OVH_REDIRECT("www", "https://designcoach.pl", 302),
 
   MX("@", 10, "mx3.mail.ovh.net."),
   MX("@", 1, "mx4.mail.ovh.net."),

--- a/dns/functions/ovh_redirect.js
+++ b/dns/functions/ovh_redirect.js
@@ -1,0 +1,13 @@
+function OVH_REDIRECT(domain, target, code) {
+  code     = +code;
+  var type = code === 302 ? "1" : code === 301 ? "4" : false;
+
+  if(type === false) {
+    return;
+  }
+
+  return [
+    TXT(domain, code + "|" + target, TTL(60)),
+    A(domain, OVH_REDIR_SERVER, TTL(0))
+  ];
+}

--- a/dns/providers.js
+++ b/dns/providers.js
@@ -1,11 +1,12 @@
 // Registrars
-var REGISTRAR_NONE = NewRegistrar("none", "NONE")
-var REGISTRAR_OVH = NewRegistrar("ovh", "OVH")
+var REGISTRAR_NONE = NewRegistrar("none", "NONE");
+var REGISTRAR_OVH  = NewRegistrar("ovh", "OVH");
 
 // DNS Providers
-var PROVIDER_CLOUDFLARE = NewDnsProvider("cloudflare", "CLOUDFLAREAPI")
-var PROVIDER_OVH = NewDnsProvider("ovh", "OVH")
+var PROVIDER_CLOUDFLARE = NewDnsProvider("cloudflare", "CLOUDFLAREAPI");
+var PROVIDER_OVH        = NewDnsProvider("ovh", "OVH");
 
 // Other definitions
-var LUTHARON = IP("151.80.140.22") // Lutharon VPS IP address
-var ZENBOX_DCOACH = IP("2.57.138.154") // Zenbox DesignCoach server IP
+var LUTHARON         = IP("151.80.140.22"); // Lutharon VPS IP address
+var ZENBOX_DCOACH    = IP("2.57.138.154"); // Zenbox DesignCoach server IP
+var OVH_REDIR_SERVER = IP("213.186.33.5"); // OVH redirects service IP


### PR DESCRIPTION
## Added
- `OVH_REDIRECT` function that sets TXT record for OVH-managed redirects and points domain to the OVH redirect server
- `OVH_REDIR_SERVER` IP variable holding an address of the OVH redirect server

## Changed
- Redirections:
  - [www.]akademiaurzadzania.pl -> https://designcoach.pl
  - [www.]homecoach.pl -> https://designcoach.pl
  - [www.]wnetrzabardzoosobiste.pl -> https://designcoach.pl
  - [www.]qubatura.art -> https://qubatura.com.pl