### PR TITLE
Fix OVH redirect TXT record

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,10 +26,10 @@ domain/akademiaurzadzania.pl:
   - dns/domains/akademiaurzadzania.pl.js
 
 domain/homecoach.pl:
-  - dns/domain/homecoach.pl.js
+  - dns/domains/homecoach.pl.js
 
 domain/wnetrzabardzoosobiste.pl:
-  - dns/domain/wnetrzabardzoosobiste.pl.js
+  - dns/domains/wnetrzabardzoosobiste.pl.js
 
 # Domain groups/families
 group/qubatura_company:
@@ -45,5 +45,5 @@ group/qubatura_company:
 group/designcoach:
   - dns/domains/designcoach.pl.js
   - dns/domains/akademiaurzadzania.pl.js
-  - dns/domain/homecoach.pl.js
-  - dns/domain/wnetrzabardzoosobiste.pl.js
+  - dns/domains/homecoach.pl.js
+  - dns/domains/wnetrzabardzoosobiste.pl.js

--- a/dns/functions/ovh_redirect.js
+++ b/dns/functions/ovh_redirect.js
@@ -7,7 +7,7 @@ function OVH_REDIRECT(domain, target, code) {
   }
 
   return [
-    TXT(domain, code + "|" + target, TTL(60)),
+    TXT(domain, type + "|" + target, TTL(60)),
     A(domain, OVH_REDIR_SERVER, TTL(0))
   ];
 }


### PR DESCRIPTION
## Fixed
- `OVH_REDIRECT` function — TXT record was set with the wrong code (`code` variable was used instead of `type`)
- `labeler.yml` config file was corrected to match wnetrzabardzoosobiste.pl and homecoach.pl domains