### PR TITLE
Finish azym migration; Zen panel domain change

### DIFF
--- a/dns/domains/designcoach.pl.js
+++ b/dns/domains/designcoach.pl.js
@@ -5,7 +5,7 @@ D("designcoach.pl", REGISTRAR_OVH, DnsProvider(PROVIDER_OVH),
   A("*", ZENBOX_DCOACH),
   A("www", ZENBOX_DCOACH),
   A("localhost", IP("127.0.0.1")),
-  A("admin", LUTHARON),
+  A("admin", AZYMONDIAS),
 
   MX("@", 10, "mx1.zenbox.pl."),
   MX("@", 20, "mx1.zenbox.pl."),

--- a/dns/domains/f4dev.me.js
+++ b/dns/domains/f4dev.me.js
@@ -1,5 +1,5 @@
 D("f4dev.me", REGISTRAR_NONE, DnsProvider(PROVIDER_CLOUDFLARE),
-    A("*", LUTHARON),
+    A("*", AZYMONDIAS),
     // GitHub Pages
     A("@", "192.30.252.153", CF_PROXY_ON),
     A("@", "192.30.252.154", CF_PROXY_ON),

--- a/dns/domains/f4dev.me.js
+++ b/dns/domains/f4dev.me.js
@@ -18,6 +18,8 @@ D("f4dev.me", REGISTRAR_NONE, DnsProvider(PROVIDER_CLOUDFLARE),
     TXT("asuid.zhp-tests", "59AD87167F51C48A766AD27F7323B2C08FF48AE5A2B5C67D7CF6A80F216A7E66"),
     CNAME("www.zhp-tests", "zhp-tests.azurewebsites.net."),
     TXT("www.asuid.zhp-tests", "59AD87167F51C48A766AD27F7323B2C08FF48AE5A2B5C67D7CF6A80F216A7E66"),
+    // Old Zen panel
+    OVH_REDIRECT("zen-cms", "https://panel.zencentrum.pl", 301),
 
     // M365 configuration
     MX("@", 0, "f4dev-me.mail.protection.outlook.com."),

--- a/dns/domains/qubatura.com.pl.js
+++ b/dns/domains/qubatura.com.pl.js
@@ -1,9 +1,9 @@
 D("qubatura.com.pl", REGISTRAR_OVH, DnsProvider(PROVIDER_OVH),
   DefaultTTL(3600),
 
-  A("@", LUTHARON),
-  A("*", LUTHARON),
-  A("www", LUTHARON),
+  A("@", AZYMONDIAS),
+  A("*", AZYMONDIAS),
+  A("www", AZYMONDIAS),
 
   MX("@", 10, "mx1.zenbox.pl."),
   MX("@", 20, "mx1.zenbox.pl."),

--- a/dns/domains/robroyart.xyz.js
+++ b/dns/domains/robroyart.xyz.js
@@ -1,9 +1,9 @@
 D("robroyart.xyz", REGISTRAR_NONE, DnsProvider(PROVIDER_CLOUDFLARE),
     DefaultTTL(1),
 
-    A("*", LUTHARON),
-    A("@", LUTHARON, CF_PROXY_OFF),
-    A("www", LUTHARON, CF_PROXY_OFF),
+    A("*", AZYMONDIAS),
+    A("@", AZYMONDIAS, CF_PROXY_OFF),
+    A("www", AZYMONDIAS, CF_PROXY_OFF),
 
     MX('@', 10, 'eforward1.registrar-servers.com.'),
     MX('@', 10, 'eforward2.registrar-servers.com.'),

--- a/dns/providers.js
+++ b/dns/providers.js
@@ -7,6 +7,6 @@ var PROVIDER_CLOUDFLARE = NewDnsProvider("cloudflare", "CLOUDFLAREAPI");
 var PROVIDER_OVH        = NewDnsProvider("ovh", "OVH");
 
 // Other definitions
-var LUTHARON         = IP("217.182.78.46"); // Lutharon VPS IP address
+var AZYMONDIAS         = IP("217.182.78.46"); // Lutharon VPS IP address
 var ZENBOX_DCOACH    = IP("2.57.138.154"); // Zenbox DesignCoach server IP
 var OVH_REDIR_SERVER = IP("213.186.33.5"); // OVH redirects service IP


### PR DESCRIPTION
## Changed
- Renamed `LUTHARON` IP variable to `AZYMONDIAS`

## Added
- OVH redirect from `zen-cms.f4dev.me` to `panel.zencentrum.pl`