### PR TITLE
Add `eduquality.eu` domain & subdomains

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,6 +31,9 @@ domain/homecoach.pl:
 domain/wnetrzabardzoosobiste.pl:
   - dns/domains/wnetrzabardzoosobiste.pl.js
 
+domain/eduquality.eu:
+  - dns/domains/eduquality.eu.js
+
 # Domain groups/families
 group/qubatura_company:
   - dns/domains/robroyart.xyz.js

--- a/dns/domains/eduquality.eu.js
+++ b/dns/domains/eduquality.eu.js
@@ -1,0 +1,22 @@
+D("eduquality.eu", REGISTRAR_OVH, DnsProvider(PROVIDER_OVH),
+    DefaultTTL(3600),
+
+    A('@', '213.186.33.5'),
+    A('www', '213.186.33.5'),
+
+    MX('@', 100, 'mx3.mail.ovh.net.'),
+    MX('@', 1, 'mx1.mail.ovh.net.'),
+    MX('@', 5, 'mx2.mail.ovh.net.'),
+
+    TXT('@', '1|www.eduquality.eu'),
+    TXT('@', 'v=spf1 include:mx.ovh.com ~all'),
+    TXT('www', '3|welcome'),
+
+    CNAME('autoconfig', 'mailconfig.ovh.net.'),
+    CNAME('autodiscover', 'mailconfig.ovh.net.'),
+    CNAME('ftp', 'eduquality.eu.'),
+
+    SRV('_autodiscover._tcp', 0, 0, 443, 'mailconfig.ovh.net.'),
+    SRV('_imaps._tcp', 0, 0, 993, 'ssl0.ovh.net.'),
+    SRV('_submission._tcp', 0, 0, 465, 'ssl0.ovh.net.')
+)

--- a/dns/domains/eduquality.eu.js
+++ b/dns/domains/eduquality.eu.js
@@ -12,6 +12,7 @@ D("eduquality.eu", REGISTRAR_OVH, DnsProvider(PROVIDER_OVH),
     TXT('@', 'v=spf1 include:mx.ovh.com ~all'),
     TXT('www', '3|welcome'),
 
+    CNAME("staging", "kovansky.github.io."),
     CNAME('autoconfig', 'mailconfig.ovh.net.'),
     CNAME('autodiscover', 'mailconfig.ovh.net.'),
     CNAME('ftp', 'eduquality.eu.'),

--- a/dns/domains/eduquality.eu.js
+++ b/dns/domains/eduquality.eu.js
@@ -8,11 +8,11 @@ D("eduquality.eu", REGISTRAR_OVH, DnsProvider(PROVIDER_OVH),
     MX('@', 1, 'mx1.mail.ovh.net.'),
     MX('@', 5, 'mx2.mail.ovh.net.'),
 
-    TXT('@', '1|www.eduquality.eu'),
     TXT('@', 'v=spf1 include:mx.ovh.com ~all'),
-    TXT('www', '3|welcome'),
 
+    // Github Pages
     CNAME("staging", "kovansky.github.io."),
+    // OVH defaults
     CNAME('autoconfig', 'mailconfig.ovh.net.'),
     CNAME('autodiscover', 'mailconfig.ovh.net.'),
     CNAME('ftp', 'eduquality.eu.'),


### PR DESCRIPTION
## Added
- `eduquality.eu` base domain
  - Added `staging.eduquality.eu` redireciton to Github Pages

## Removed
- Removed default OVH redirection from `eduquality.eu` and `www.eduquality.eu` to ugly OVH page