### PR TITLE
Stardust fix; f4dev DMARC

### DIFF
--- a/dns/domains/f4dev.me.js
+++ b/dns/domains/f4dev.me.js
@@ -19,7 +19,7 @@ D("f4dev.me", REGISTRAR_NONE, DnsProvider(PROVIDER_CLOUDFLARE),
     A("ufo.cms", LUTHARON, CF_PROXY_OFF),
     A("ufo.preview", AZYMONDIAS, CF_PROXY_OFF),
     // Design system - UFO
-    CNAME("stardust.ufo", "kovansky.github.io.", CF_PROXY_ON), // Github Pages
+    CNAME("stardust.ufo", "kovansky.github.io.", CF_PROXY_OFF), // Github Pages
     // ZHP tests
     CNAME("zhp-tests", "zhp-tests.azurewebsites.net."),
     TXT("asuid.zhp-tests", "59AD87167F51C48A766AD27F7323B2C08FF48AE5A2B5C67D7CF6A80F216A7E66"),
@@ -37,7 +37,7 @@ D("f4dev.me", REGISTRAR_NONE, DnsProvider(PROVIDER_CLOUDFLARE),
 
     // M365 configuration
     TXT("default._domainkey", "v=DKIM1; k=rsa; s=email; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+kqPUJ7zu9Cjl/XOEaE7IGh+1f70Xelv0xwS5eQYh9ZQZdsfs74cc3lxgFr66ysDyD6wV41qyi/8r5A17HWMSiZ2KC6yqohPXh37J/DRIaw4Pfxcl2CAdxWeQFqtqoLvzf5AX1qFzoOz8oqPb0OpPs2TGMPyvnpYSUC1jcvGTDQIDAQAB"),
-    TXT("_dmarc", "v=DMARC1;p=none;rua=mailto:8c96870c92@rua.easydmarc.eu,mailto:root@f4dev.me;ruf=mailto:8c96870c92@ruf.easydmarc.eu;fo=1"), // EasyDMARC
+    TXT("_dmarc", "v=DMARC1;p=none;rua=mailto:8c96870c92@rua.easydmarc.eu,mailto:root@f4dev.me,mailto:4dcf81fb10834d589a8ecb4fc5cd665a@dmarc-reports.cloudflare.net;ruf=mailto:8c96870c92@ruf.easydmarc.eu;fo=1"), // EasyDMARC; Cloudflare DMARC Management
 
     SPF_BUILDER({
         label: "@",


### PR DESCRIPTION
## Fixed
- Disabled CF Proxy for `stardust.ufo.f4dev.me` (it denies the SSL cert)

## Changed
- Added Cloudflare DMARC address for `f4dev.me`