### PR TITLE
Add subdomains for hufiec migration preview

### DIFF
--- a/dns/domains/f4dev.me.js
+++ b/dns/domains/f4dev.me.js
@@ -1,6 +1,11 @@
 D("f4dev.me", REGISTRAR_NONE, DnsProvider(PROVIDER_CLOUDFLARE),
     A("*", AZYMONDIAS),
 
+    // ZHP Migration
+    A("hufiec", DOMENOMANIA_ZHP),
+    A("5dw", DOMENOMANIA_ZHP),
+    A("platforma2", DOMENOMANIA_ZHP),
+
     // GitHub Pages f4dev
     A("@", "192.30.252.153", CF_PROXY_ON),
     A("@", "192.30.252.154", CF_PROXY_ON),

--- a/dns/providers.js
+++ b/dns/providers.js
@@ -8,6 +8,6 @@ var PROVIDER_OVH = NewDnsProvider("ovh");
 
 // Other definitions
 var AZYMONDIAS = IP("217.182.78.46"); // Azymondias VPS IP address
-var ZENBOX_DCOACH = IP("2.57.138.154"); // Zenbox DesignCoach server IP
 var DOMENOMANIA_DCOACH = IP("185.17.40.218"); // Domenomania DesignCoach server IP
+var DOMENOMANIA_ZHP = IP("185.17.40.218"); // Domenomania ZHP server IP
 var OVH_REDIR_SERVER = IP("213.186.33.5"); // OVH redirects service IP


### PR DESCRIPTION
## Added
- `f4dev.me`
  - `hufiec.`, `5dw.`, `platforma2.` subdomains pointing to Domenomania ZHP server (A)