### PR TITLE
[Tycidomki] Add static subdomain

### DIFF
--- a/dns/domains/tycidomki.pl.js
+++ b/dns/domains/tycidomki.pl.js
@@ -4,6 +4,7 @@ D("tycidomki.pl", REGISTRAR_OVH, DnsProvider(PROVIDER_OVH),
 	A('@', AZYMONDIAS),
 	A('www', AZYMONDIAS),
 	A('panel', AZYMONDIAS),
+	A('static', AZYMONDIAS),
 
 	A("mail", DOMENOMANIA_DCOACH),
 	MX("@", 0, "mail.tycidomki.pl."),


### PR DESCRIPTION
This pull request includes a small change to the `dns/domains/tycidomki.pl.js` file. The change adds a new DNS record for the `static` subdomain.

* [`dns/domains/tycidomki.pl.js`](diffhunk://#diff-0898decda161210bc9ceae208d4be1160784f76a4a14bf15b4cb3b4ce2db9d88R7): Added a DNS record for the `static` subdomain pointing to `AZYMONDIAS`.